### PR TITLE
Accept ssh git urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Tracks an existing change from the current branch
 
 You will need JDK 9+.
 
+Currently with OpenJDK 11 there is a need for a newer version of gradle, which causes issues with the buildscript, and with OpenJDK 10 I came across a certificate issue when the buildscript tried to download the Azul JRE 9 to build the binary.
+
+It works perfectly with Azul JDK 9.0.7
+
 ```xml
 <dependency>
    <groupId>com.cosium.vet</groupId>

--- a/src/main/java/com/cosium/vet/gerrit/DefaultChangeRepositoryFactory.java
+++ b/src/main/java/com/cosium/vet/gerrit/DefaultChangeRepositoryFactory.java
@@ -10,6 +10,7 @@ import com.cosium.vet.git.RemoteUrl;
 import com.cosium.vet.log.Logger;
 import com.cosium.vet.log.LoggerFactory;
 
+import java.net.URI;
 import java.net.URL;
 
 import static java.util.Objects.requireNonNull;
@@ -42,9 +43,9 @@ public class DefaultChangeRepositoryFactory implements ChangeRepositoryFactory {
     GerritConfigurationRepository configurationRepository = configurationRepositoryFactory.build();
 
     RemoteName remote = RemoteName.ORIGIN;
-    URL remoteUrl =
+    String remoteUrl =
         git.getRemotePushUrl(remote)
-            .map(RemoteUrl::toURL)
+            .map(RemoteUrl::toString)
             .orElseThrow(
                 () ->
                     new RuntimeException(
@@ -52,7 +53,7 @@ public class DefaultChangeRepositoryFactory implements ChangeRepositoryFactory {
                             "Could not find url of remote '%s'. Please verify that you are in a valid git repository.",
                             remote)));
 
-    PushUrl pushUrl = PushUrl.of(remoteUrl.toString());
+    PushUrl pushUrl = PushUrl.of(remoteUrl);
     LOG.debug("Gerrit push url is {}", pushUrl);
     ProjectName projectName = pushUrl.parseProjectName();
     LOG.debug("Gerrit project is '{}'", projectName);

--- a/src/main/java/com/cosium/vet/git/RemoteUrl.java
+++ b/src/main/java/com/cosium/vet/git/RemoteUrl.java
@@ -2,9 +2,6 @@ package com.cosium.vet.git;
 
 import com.cosium.vet.utils.NonBlankString;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-
 /**
  * Created on 21/02/18.
  *
@@ -12,19 +9,12 @@ import java.net.URL;
  */
 public class RemoteUrl extends NonBlankString {
 
-  private RemoteUrl(String value) {
-    super(value);
-  }
-
-  public static RemoteUrl of(String url) {
-    return new RemoteUrl(url);
-  }
-
-  public URL toURL() {
-    try {
-      return new URL(toString());
-    } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(e);
+    private RemoteUrl(String value) {
+        super(value);
     }
-  }
+
+    public static RemoteUrl of(String url) {
+        return new RemoteUrl(url);
+    }
+
 }


### PR DESCRIPTION
Remove RemoteUrl#toURL and just use a toString() to work with remotes that
use ssh instead of http.

This removes some validation on the URL through the new URL()
constructor, but it was causing an exception with ssh remotes.